### PR TITLE
Use sentence casing for README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sparksuite’s Employee Handbook
+# Sparksuite’s employee handbook
 
 Greetings! We’ve open sourced our employee handbook so that team members, prospective employees, and others can track the changes we’ve made over time and contribute to it as it evolves. Although it’s stored on GitHub, we decided to structure the handbook as a static website so that non-technical team members could view it easily too. To check out the handbook, visit: https://handbook.sparksuite.com/.
 


### PR DESCRIPTION
This follows the pattern used by our salary calculator, and matches the company-preferred stylization of headers.