### PR TITLE
Tiny bug fixes

### DIFF
--- a/benefits/health.html
+++ b/benefits/health.html
@@ -216,7 +216,7 @@
 
 					<ul>
 						<li>
-							<strong> Can a family mix-and-match the above health plans? </strong>
+							<strong>Can a family mix-and-match the above health plans?</strong>
 							Unfortunately, no. Family members must use the same plan the employee chooses, or opt for coverage from
 							elsewhere.
 						</li>

--- a/hiring/piiaa.html
+++ b/hiring/piiaa.html
@@ -37,7 +37,7 @@
 
 					<p>
 						Because the document has quite a bit of formatting, it’s better to view the agreement as a PDF here:
-						<a href="piiaa.pdf" target="_blank" rel="noopener noreferrer">PIIAA Agreement</a>.
+						<a href="piiaa.pdf" target="_blank">PIIAA Agreement</a>.
 					</p>
 				</div>
 			</div>

--- a/people-operations/payroll-information.html
+++ b/people-operations/payroll-information.html
@@ -33,7 +33,7 @@
 					<p>
 						If a payday falls on a weekend or bank holiday, the payday will occur on the closest business day leading up
 						to the normal payday
-						<em> (e.g., if the 15th was a Sunday, the direct deposit would arrive on the 13th.) </em>
+						<em>(e.g., if the 15th was a Sunday, the direct deposit would arrive on the 13th.)</em>
 					</p>
 
 					<p>


### PR DESCRIPTION
This removes some unintended spaces inserted into a couple of inline tags (caused by changing the `printWidth`), and removes the `rel` attribute on an internal link.