### PR TITLE
Fix icon centering in footer on mobile

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -49,7 +49,7 @@ class SharedFooter extends HTMLElement {
 				<div class="w-100 d-flex d-sm-none"></div>
 
 				<ul class="nav col-md-4 justify-content-end list-unstyled d-flex">
-					<li class="ms-3">
+					<li>
 						<a class="text-muted" href="https://twitter.com/SparksuiteHQ" target="_blank" rel="noopener noreferrer">
 							<svg class="bi" width="24" height="24" fill="currentColor"><use xlink:href="#twitter" /></svg>
 						</a>


### PR DESCRIPTION
### Before

<img width="375" alt="Screen Shot 2022-02-16 at 10 23 35 AM" src="https://user-images.githubusercontent.com/3850064/154310143-ef74d24c-4154-4e21-9ff9-a90bee80705f.png">

### After

<img width="375" alt="Screen Shot 2022-02-16 at 10 23 25 AM" src="https://user-images.githubusercontent.com/3850064/154310115-10d7e0d4-74aa-4fcf-a2e9-6a831baeb008.png">
