### PR TITLE
Indicate what happens to unused PTO balance

### DIFF
--- a/benefits/paid-time-off.html
+++ b/benefits/paid-time-off.html
@@ -107,6 +107,10 @@
 						Time off can be taken in half-hour increments. It’s preferred that you don’t dip too low into your paid time
 						off balance, to ensure you can cover unexpected time off (like illness).
 					</p>
+
+					<h5 class="pt-2">Unused balance</h5>
+
+					<p>Any unused PTO balance will be paid out with the final paycheck if an employee leaves the company.</p>
 				</div>
 			</div>
 		</main>


### PR DESCRIPTION
This PR adds a paragraph to the "Paid time off" page indicating what happens to an employee's unused PTO balance if they leave the company.