### PR TITLE
Add anniversary swag as a perk

### DIFF
--- a/benefits/anniversary-swag.html
+++ b/benefits/anniversary-swag.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<link rel="icon" href="../images/favicon.png" />
+
+		<title>Anniversary Swag - Employee Handbook</title>
+
+		<link href="../css/main.css" rel="stylesheet" />
+		<script src="../components/footer.js" type="text/javascript" defer></script>
+		<script defer data-domain="handbook.sparksuite.com" src="https://plausible.io/js/script.js"></script>
+	</head>
+
+	<body class="py-4">
+		<header class="container">
+			<h1 class="text-muted mb-2 h3">Sparksuite’s Employee Handbook</h1>
+		</header>
+
+		<main class="container">
+			<div class="row">
+				<div class="col">
+					<a href="../index.html" class="d-block pb-4">&larr; Back to home</a>
+
+					<h2 class="display-6">Anniversary swag</h2>
+
+					<p>
+						We strive to retain team members for a long time, so as a fun way of showing off how long you’ve worked in the Sparksuite family, we reward team members with desirable company swag after crossing various work anniversary milestones! Plus, we dish these products out at all-hands meetings so the whole team can celebrate together. Here’s our current lineup of company swag:
+					</p>
+
+					<ul>
+						<li><strong>Start date:</strong> T-shirt (<a href="https://www.instagram.com/p/Ccokh8Zqqwi/" target="_blank" rel="noopener noreferrer">see it</a>) &amp; hat (<a href="https://www.instagram.com/p/CVf78g2vOBV/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+						<li><strong>1 year:</strong> Sttoke mug (<a href="https://www.instagram.com/p/CYujtnlvMxk/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+						<li><strong>3 year:</strong> Nike Dri-FIT shirt (<a href="https://www.instagram.com/p/CnX4Mohq8tD/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+						<li><strong>5 year:</strong> Patagonia Torrentshell rain jacket (<a href="https://www.instagram.com/p/CjtPLaJKSbb/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+						<li><strong>7 year:</strong> Puffer jacket
+						<li><strong>10 year:</strong> Columbia Falmouth backpack (<a href="https://www.instagram.com/p/CaiYLO1qw47/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+					</ul>
+				</div>
+			</div>
+		</main>
+
+		<footer class="container">
+			<shared-footer></shared-footer>
+		</footer>
+	</body>
+</html>

--- a/benefits/anniversary-swag.html
+++ b/benefits/anniversary-swag.html
@@ -25,16 +25,56 @@
 					<h2 class="display-6">Anniversary swag</h2>
 
 					<p>
-						We strive to retain team members for a long time, so as a fun way of showing off how long you’ve worked in the Sparksuite family, we reward team members with desirable company swag after crossing various work anniversary milestones! Plus, we dish these products out at all-hands meetings so the whole team can celebrate together. Here’s our current lineup of company swag:
+						We strive to retain team members for a long time, so as a fun way of showing off how long you’ve worked in
+						the Sparksuite family, we reward team members with desirable company swag after crossing various work
+						anniversary milestones! Plus, we dish these products out at all-hands meetings so the whole team can
+						celebrate together. Here’s our current lineup of company swag:
 					</p>
 
 					<ul>
-						<li><strong>Start date:</strong> T-shirt (<a href="https://www.instagram.com/p/Ccokh8Zqqwi/" target="_blank" rel="noopener noreferrer">see it</a>) &amp; hat (<a href="https://www.instagram.com/p/CVf78g2vOBV/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
-						<li><strong>1 year:</strong> Sttoke mug (<a href="https://www.instagram.com/p/CYujtnlvMxk/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
-						<li><strong>3 year:</strong> Nike Dri-FIT shirt (<a href="https://www.instagram.com/p/CnX4Mohq8tD/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
-						<li><strong>5 year:</strong> Patagonia Torrentshell rain jacket (<a href="https://www.instagram.com/p/CjtPLaJKSbb/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
-						<li><strong>7 year:</strong> Puffer jacket
-						<li><strong>10 year:</strong> Columbia Falmouth backpack (<a href="https://www.instagram.com/p/CaiYLO1qw47/" target="_blank" rel="noopener noreferrer">see it</a>)</li>
+						<li>
+							<strong>Start date:</strong> T-shirt (<a
+								href="https://www.instagram.com/p/Ccokh8Zqqwi/"
+								target="_blank"
+								rel="noopener noreferrer"
+								>see it</a
+							>) &amp; hat (<a href="https://www.instagram.com/p/CVf78g2vOBV/" target="_blank" rel="noopener noreferrer"
+								>see it</a
+							>)
+						</li>
+						<li>
+							<strong>1 year:</strong> Sttoke mug (<a
+								href="https://www.instagram.com/p/CYujtnlvMxk/"
+								target="_blank"
+								rel="noopener noreferrer"
+								>see it</a
+							>)
+						</li>
+						<li>
+							<strong>3 year:</strong> Nike Dri-FIT shirt (<a
+								href="https://www.instagram.com/p/CnX4Mohq8tD/"
+								target="_blank"
+								rel="noopener noreferrer"
+								>see it</a
+							>)
+						</li>
+						<li>
+							<strong>5 year:</strong> Patagonia Torrentshell rain jacket (<a
+								href="https://www.instagram.com/p/CjtPLaJKSbb/"
+								target="_blank"
+								rel="noopener noreferrer"
+								>see it</a
+							>)
+						</li>
+						<li><strong>7 year:</strong> Puffer jacket</li>
+						<li>
+							<strong>10 year:</strong> Columbia Falmouth backpack (<a
+								href="https://www.instagram.com/p/CaiYLO1qw47/"
+								target="_blank"
+								rel="noopener noreferrer"
+								>see it</a
+							>)
+						</li>
 					</ul>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -183,6 +183,16 @@
 
 					<div class="col-12 col-sm-6">
 						<h4>
+							<a href="./benefits/anniversary-swag.html">
+								<i class="fa-regular fa-gift opacity-50 me-1"></i> Anniversary swag
+							</a>
+						</h4>
+
+						<p>Rock company swag after hitting work anniversary milestones.</p>
+					</div>
+
+					<div class="col-12 col-sm-6">
+						<h4>
 							<a href="./benefits/new-parent-leave.html">
 								<i class="fa-regular fa-baby-carriage opacity-50 me-1"></i> New parent leave
 							</a>


### PR DESCRIPTION
This PR introduces a new perk, which we've had for a while now, but wasn't mentioned in our employee handbook. That is, the work anniversary swag we give out after crossing certain anniversary milestones.