### PR TITLE
Introduce improved “extra remote day” policy

### DIFF
--- a/benefits/flexible-remote-work.html
+++ b/benefits/flexible-remote-work.html
@@ -25,8 +25,26 @@
 					<h2 class="display-6">Flexible remote work</h2>
 
 					<p>
-						To promote a healthy work-life balance, team members can work remotely up to 2 days each week. No need to
-						gain approval in advance.
+						To promote a healthy work-life balance, team members can work remotely up to 2 days each week, with extra
+						remote days available to accommodate unexpected situations (details below). Each team member has full
+						control over when they choose to use their remote days—no approval or advance notice needed.
+					</p>
+
+					<h3 class="pt-2 h5">Extra remote days</h3>
+
+					<p>
+						Team members accrue one extra remote day on the first day of each quarter, up to a balance of 10 extra
+						remote days. You can use these extra remote days to work remotely more than twice in a week. While it’s up
+						to each team member to decide how and when to use their extra remote days, we recommend reserving these for
+						unexpected situations.
+					</p>
+
+					<h3 class="pt-2 h5">Mixed days</h3>
+
+					<p>
+						If needed, you can work part of the day from the office and part of the day remotely. This counts as a
+						remote day, so you’ll need to have a remote day available to do this. If you need to switch your work
+						location, just be sure to inform your manager in advance and update your work location status.
 					</p>
 
 					<h3 class="pt-2 h5">Guidance</h3>
@@ -53,12 +71,6 @@
 						Working remotely generally requires more effort to ensure it’s effective and productive. It will take extra
 						work to ensure you’re still collaborating well with your teammates and exceeding their expectations. At the
 						end of the day, your teammates are counting on you just as much as when you’re at the office.
-					</p>
-
-					<p>
-						If you have a compelling reason to work remotely more than 2 days in a particular week, please obtain
-						approval from the person you report to as much in advance as reasonably possible. Several days notice is
-						expected, except for unusual circumstances.
 					</p>
 
 					<h3 class="pt-2 h5">Why not 100% remote?</h3>


### PR DESCRIPTION
These changes are being introduced to the handbook now, but won’t take effect for team members until January 1, 2024. The improvements are designed to make the usage of extra remote days more generous, more flexible, and less ambiguous.