### PR TITLE
Remove note about half-hour increments

### DIFF
--- a/benefits/paid-time-off.html
+++ b/benefits/paid-time-off.html
@@ -94,8 +94,8 @@
 					</p>
 
 					<p>
-						Time off can be taken in half-hour increments. It’s preferred that you don’t dip too low into your paid time
-						off balance, to ensure you can cover unexpected time off (like illness).
+						It’s preferred that you don’t dip too low into your paid time off balance, to ensure you can cover
+						unexpected time off (like illness).
 					</p>
 
 					<h3 class="pt-2 h5">Unused balance</h3>


### PR DESCRIPTION
This PR removes the sentence about how PTO is expected to be taken in half-hour increments since this expectation no longer applies.