### PR TITLE
Tweak description under “Design principles” on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 							</a>
 						</h4>
 
-						<p>The principles that guide the way we design our benefits, perks, and policies.</p>
+						<p>The principles that guide the way we design our benefits, perks, compensation, and policies.</p>
 					</div>
 
 					<div class="col-12 col-sm-6">


### PR DESCRIPTION
This better matches the phrasing used on the page it links to.