### PR TITLE
Mention time(s) in notes for time off requests

### DIFF
--- a/benefits/paid-time-off.html
+++ b/benefits/paid-time-off.html
@@ -95,6 +95,11 @@
 					</p>
 
 					<p>
+						If you need to request time off for part (not all) of the day, you should include the time(s) you will be
+						out in your time off request, in the “notes” field.
+					</p>
+
+					<p>
 						It’s preferred that you don’t dip too low into your paid time off balance, to ensure you can cover
 						unexpected time off (like illness).
 					</p>

--- a/people-operations/unpaid-time-off.html
+++ b/people-operations/unpaid-time-off.html
@@ -79,6 +79,11 @@
 						bucket.
 					</p>
 
+					<p>
+						If you need to request time off for part (not all) of the day, you should include the time(s) you will be
+						out in your time off request, in the “notes” field.
+					</p>
+
 					<h3 class="pt-2 h5">Impact of using unpaid time off</h3>
 
 					<p>


### PR DESCRIPTION
This PR adds a brief mention of the inclusion of time(s) in the notes for partial-day time off requests.