### PR TITLE
Add a note to the "Office closures" page

### DIFF
--- a/people-operations/office-closures.html
+++ b/people-operations/office-closures.html
@@ -61,7 +61,14 @@
 
 					<p>Team members will be notified via Slack when the status of the office is changed.</p>
 
-					<h3 class="pt-2 h5">Note</h3>
+					<h3 class="pt-2 h5">Notes</h3>
+
+					<p>
+						Our company attempts to monitor utilities at our office within reason; however, we recognize that we may not
+						be aware of issues right away (or at all), and that some situations may be widespread (e.g., natural
+						disasters) and therefore limit our company’s awareness. To help us out, if you notice a utility issue at our
+						office, please let the appropriate team member know right away.
+					</p>
 
 					<p>
 						We’ve designed our policies to accommodate all types of unexpected events by affording a great deal of


### PR DESCRIPTION
This PR introduces a small note to the office closures page, essentially indicating we'll do our best within reason.