### PR TITLE
Clarify "full days"

### DIFF
--- a/benefits/flexible-remote-work.html
+++ b/benefits/flexible-remote-work.html
@@ -48,8 +48,8 @@
 					<p>
 						Full-time team members have the opportunity to earn half of an extra remote day in order to replenish a low
 						balance. When you have fewer than 3 extra remote days in your balance, this half extra remote day can be
-						earned by working 5 full days entirely from the office within one workweek, and it will be added to your
-						balance on the following Wednesday.
+						earned by working 5 full days (i.e., without time off) entirely from the office within one workweek, and it
+						will be added to your balance on the following Wednesday.
 					</p>
 
 					<h3 class="pt-2 h5">Mixed days</h3>


### PR DESCRIPTION
This ensures there's no confusion regarding the meaning of "full days" when discussing the mechanics of replenishing extra remote days.