### PR TITLE
Improve verbiage, particularly around insurance plans

### DIFF
--- a/benefits/additional-insurance.html
+++ b/benefits/additional-insurance.html
@@ -32,6 +32,8 @@
 						these policies, they’re designed to help team members and their families supplement their existing financial
 						safety nets.
 					</p>
+
+					<p>Coverage for these policies begins on the 1st of the month following your start date.</p>
 				</div>
 			</div>
 		</main>

--- a/benefits/health.html
+++ b/benefits/health.html
@@ -25,12 +25,12 @@
 					<h2 class="display-6">Health</h2>
 
 					<p>
-						We offer full-time team members a variety of employer-sponsored health plans with company contributions. We
-						also offer vision and dental plans, along with HSAs. The process of selecting and managing plans is made
+						We offer full-time team members a variety of employer-sponsored medical plans with company contributions. We
+						also offer dental and vision plans, along with HSAs. The process of selecting and managing plans is made
 						easy and seamless by our payroll provider.
 					</p>
 
-					<h3 class="pt-2 h5">Health plans</h3>
+					<h3 class="pt-2 h5">Medical plans</h3>
 
 					<p>
 						The following plans from
@@ -97,15 +97,15 @@
 					<h3 class="pt-2 h5">Health savings account</h3>
 
 					<p>
-						Team members with a health plan that meets the requirements for a “High Deductible Health Plan” (HDHP) can
+						Team members with a medical plan that meets the requirements for a “High Deductible Health Plan” (HDHP) can
 						optionally add a health savings account (HSA) as a tax-saving measure for many types of health expenses.
 					</p>
 
 					<h3 class="pt-2 h5">Company contribution</h3>
 
 					<p>
-						Our company will contribute 50% of the cost of the employee’s base health plan premium, toward whichever of
-						the above health plans the employee chooses. Here’s a hypothetical example of what that looks like:
+						Our company will contribute 50% of the cost of the employee’s base medical plan premium, toward whichever of
+						the above medical plans the employee chooses. Here’s a hypothetical example of what that looks like:
 					</p>
 
 					<table class="table">
@@ -169,11 +169,11 @@
 					<h3 class="pt-2 h5">Premium pricing</h3>
 
 					<p>
-						Our plans use “member-level” premiums, where each covered person’s premium is based on their age and ZIP
-						code. This is different than “composite” premiums, where employees are placed into one of four categories
+						Our medical plans use “member-level” premiums, where each covered person’s premium is based on their age.
+						This is different than “composite” premiums, where employees are placed into one of four categories
 						(employee only, employee + spouse, employee + dependents, employee + spouse + dependents). Composite
-						premiums are more common with large employers but have several shortcomings, especially with small- to
-						mid-sized employers.
+						premiums are more common with large employers but have several shortcomings for small- to mid-sized
+						employers when it comes to medical plans.
 					</p>
 
 					<p>

--- a/benefits/health.html
+++ b/benefits/health.html
@@ -154,9 +154,8 @@
 					<h3 class="pt-2 h5">Enrollment</h3>
 
 					<p>
-						For new team members, coverage can typically begin as early as the next 1st of the month following your hire
-						date. The exception to this is, if you’re hired <em>on</em> the 1st of a month, dental and vision plans can
-						begin the same day.
+						For new team members, coverage begins on the 1st of the month following your start date. The exception to
+						this is, if you start <em>on</em> the 1st of a month, dental and vision plans can begin the same day.
 					</p>
 
 					<p>

--- a/benefits/health.html
+++ b/benefits/health.html
@@ -176,6 +176,8 @@
 						employers when it comes to medical plans.
 					</p>
 
+					<p>Our dental and vision plans, however, use “composite” premiums (as described above).</p>
+
 					<p>
 						If you’re a candidate in one of our hiring processes, and you’d like an estimate for you and your family’s
 						premiums, let us know and we can provide this to you.

--- a/benefits/health.html
+++ b/benefits/health.html
@@ -144,6 +144,11 @@
 
 					<p>There is no company contribution toward dental premiums, vision premiums, or HSAs.</p>
 
+					<p>
+						<a href="../people-operations/design-principles.html#health-premium-contributions">Learn more</a> about how
+						we’ve designed our contributions to give team members maximum autonomy over their compensation.
+					</p>
+
 					<h3 class="pt-2 h5">Coverage period</h3>
 
 					<p>

--- a/index.html
+++ b/index.html
@@ -68,8 +68,8 @@
 						</h4>
 
 						<p>
-							We offer a variety of employer-sponsored health plans from a large insurance carrier, plus vision, dental,
-							and HSAs.
+							We offer a variety of employer-sponsored medical plans from a large insurance carrier, plus vision,
+							dental, and HSAs.
 						</p>
 					</div>
 

--- a/index.html
+++ b/index.html
@@ -68,8 +68,8 @@
 						</h4>
 
 						<p>
-							We offer a variety of employer-sponsored medical plans from a large insurance carrier, plus vision,
-							dental, and HSAs.
+							We offer a variety of employer-sponsored medical plans from a large insurance carrier, plus dental,
+							vision, and HSAs.
 						</p>
 					</div>
 

--- a/people-operations/design-principles.html
+++ b/people-operations/design-principles.html
@@ -112,7 +112,7 @@
 						members as much autonomy as possible when managing their benefits. We intentionally maximize team members’
 						salaries and minimize the company contribution toward health premiums. By putting more of the total
 						compensation into salaries, team members have the opportunity to determine where their money goes, whether
-						that is more to their health plan, or more toward hobbies, travel, savings, or any other interests.
+						that is more to their health plans, or more toward hobbies, travel, savings, or any other interests.
 						Ultimately, our goal with this approach is to offer the same amount of <em>total</em> compensation while
 						affording team members the flexibility to allocate their money in ways that best fit their needs.
 					</p>

--- a/people-operations/design-principles.html
+++ b/people-operations/design-principles.html
@@ -105,16 +105,21 @@
 						letting each team member decide how to make that work with their preferences and schedule.
 					</p>
 
-					<h3 class="pt-2 h5">Health premium contributions</h3>
+					<h3 class="pt-2 h5" id="health-premium-contributions">Health premium contributions</h3>
 
 					<p>
-						We have designed our <a href="../benefits/health.html">health</a> contributions in a way that gives team
-						members as much autonomy as possible when managing their benefits. We intentionally maximize team members’
-						salaries and minimize the company contribution toward health premiums. By putting more of the total
-						compensation into salaries, team members have the opportunity to determine where their money goes, whether
-						that is more to their health plans, or more toward hobbies, travel, savings, or any other interests.
-						Ultimately, our goal with this approach is to offer the same amount of <em>total</em> compensation while
-						affording team members the flexibility to allocate their money in ways that best fit their needs.
+						We have designed our <a href="../benefits/health.html">health</a> contributions to give team members as much
+						autonomy as possible when managing how their compensation is allocated. We intentionally maximize team
+						member salaries and minimize the company contribution toward health premiums. A company’s contribution
+						toward premiums is still part of your total compensation—it’s simply been allocated to health coverage
+						without you having a say. The more a company contributes, the more of your total compensation gets committed
+						to premiums regardless of whether that’s how you’d choose to spend it, which can leave you contributing more
+						than you’d prefer and with less take-home pay. By putting those dollars into salaries instead, the
+						determination of how to allocate compensation is simply shifted from the company to team members—whether
+						that’s more toward health plans (still pre-tax), or more toward hobbies, travel, savings, or any other
+						interests. Ultimately, our goal with this approach is to offer team members the same amount of
+						<em>total</em> compensation while affording them maximum flexibility to allocate their money in ways that
+						best fit their needs.
 					</p>
 
 					<h3 class="pt-2 h5">Reducing uncertainty</h3>


### PR DESCRIPTION
This PR tightens the terminology around health plans; in particular, preferring the more accurate term "medical" plan when appropriate (leaving "health" plan to refer to medical/dental/vision). It also specifies the type of premiums used for dental/vision plans and clarifies when coverage starts for various insurance plans. Finally, it better explains the rationale for how we've designed health plan contributions and adds a new link to the rationale from the "Health plans" page.